### PR TITLE
Update links to default branch to `main`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased (`master`)
+# Unreleased (`main`)
 
 Drop official support for Ruby 2.3 and below, and Rails 4, though
 these versions may continue to work.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Code Coverage](https://codecov.io/gh/panorama-ed/unique_attributes/branch/master/graph/badge.svg)](https://codecov.io/gh/panorama-ed/unique_attributes)
+[![Code Coverage](https://codecov.io/gh/panorama-ed/unique_attributes/branch/main/graph/badge.svg)](https://codecov.io/gh/panorama-ed/unique_attributes)
 [![Inline docs](http://inch-ci.org/github/panorama-ed/unique_attributes.png)](http://inch-ci.org/github/panorama-ed/unique_attributes)
 [![Build Status](https://travis-ci.com/panorama-ed/unique_attributes.svg)](https://travis-ci.com/panorama-ed/unique_attributes)
 [![Gem Version](https://badge.fury.io/rb/unique_attributes.svg)](http://badge.fury.io/rb/unique_attributes)
@@ -113,4 +113,4 @@ and conform to the Rubocop style specified.** We use
 ## License
 
 UniqueAttributes is released under the
-[MIT License](https://github.com/panorama-ed/unique_attributes/blob/master/LICENSE.txt).
+[MIT License](https://github.com/panorama-ed/unique_attributes/blob/main/LICENSE.txt).


### PR DESCRIPTION
We have changed the default branch from `master` to `main`. This commit
updates references to the `master` branch to refer instead to the `main`
branch.